### PR TITLE
extract route

### DIFF
--- a/pks/__init__.py
+++ b/pks/__init__.py
@@ -2,6 +2,7 @@ import sys
 from pathlib import Path
 import logging
 
+from flask import Flask
 import pandas as pd
 from dash import Dash, dcc, html, Input, Output, State, callback, dash_table
 import dash_bootstrap_components as dbc
@@ -31,7 +32,7 @@ logging.basicConfig(
 )
 
 
-def init_dashboard(server):
+def init_dashboard(flask_app, route):
 
     data_raw = pd.read_parquet(
         dashapp_rootdir / "data" / "processed" / "pks.parquet")
@@ -132,8 +133,8 @@ def init_dashboard(server):
     #                                   Layout
     # -----------------------------------------------------------------------------
     app = Dash(__name__,
-               server=server,
-               routes_pathname_prefix="/pks/",
+               server=flask_app,
+               routes_pathname_prefix=route,
                external_stylesheets=[dbc.themes.FLATLY],
                )
 

--- a/pks/dashboard.py
+++ b/pks/dashboard.py
@@ -3,5 +3,5 @@ from . import init_dashboard
 
 
 app = Flask(__name__, instance_relative_config=False)
-app = init_dashboard(app)
-app.run(host="0.0.0.0", port=8080, debug=False, load_dotenv=False)
+app = init_dashboard(app, route="/")
+app.run(host="0.0.0.0", port=8080, debug=True, load_dotenv=False)


### PR DESCRIPTION
The init_dashboard() function gets an extra argument, "route". For local testing, it just gets defaulted by the test launcher dashboard.py to "/". But a Flask app can put a useful route here.